### PR TITLE
Add `bind-js` macro

### DIFF
--- a/src/evaluator/evaluator.js
+++ b/src/evaluator/evaluator.js
@@ -230,12 +230,11 @@ async function evaluateItem(form, context) {
 
   switch (typeof form) {
     case "object":
-      if (form === null) {
-        return form;
-      }
-
       if (isEmbeddedJavascript(form)) {
         return new AsyncFunction(form.getJsCode()).bind(context);
+      }
+      if (form === null || !form[Symbol.for('@@jisp-map@@')]) {
+        return form;
       }
 
       const entries = [];

--- a/src/jisp/core.jisp
+++ b/src/jisp/core.jisp
@@ -7,6 +7,24 @@
   (fn* (& args)
     nil))
 
+(defun recurse-state (obj keys state)
+  (if (empty? keys)
+    state
+    (recurse-state obj 
+                   (rest keys)
+                   (concat state 
+                           (list (list 'def! 
+                                 (symbol (first keys))
+                                 (list '. (symbol (first keys)) obj)))))))
+
+(defmacro! bind-js
+  (fn* (js-form)
+    (let* (dt ((eval js-form))
+           obj (. obj dt)
+           keys (. keys dt)
+           forms (recurse-state obj keys '()))
+      `(do ~@forms nil))))
+
 (defun load-file (path)
   (eval (read-string (str "(do " (slurp path) " nil)"))))
 
@@ -35,3 +53,36 @@
   console.log(...~@);
   return null;
 })
+
+(def! list #js{
+  return [...~@];
+})
+
+(def! count #js{
+  return @0.length;
+})
+
+(def! == #js{
+  return @0 == @1;
+})
+
+(def! === #js{
+  return @0 === @1;
+})
+
+(defun empty? (coll)
+  (=== 0 (count coll)))
+
+(def! first #js{
+  return @0[0];
+})
+
+(def! rest #js{
+  return @0.slice(1);
+})
+
+(def! symbol #js{
+  return Symbol.for(@0);
+})
+
+(bind-js #js{ return { obj: Math, keys: Object.getOwnPropertyNames(Math) }; })

--- a/src/reader/parser.js
+++ b/src/reader/parser.js
@@ -28,7 +28,7 @@ class JISPParser extends EmbeddedActionsParser {
         },
         {
           ALT: () => {
-            result = $.SUBRULE($.symbol);
+            result = $.SUBRULE($.decimalNumber);
           },
         },
         {
@@ -38,7 +38,7 @@ class JISPParser extends EmbeddedActionsParser {
         },
         {
           ALT: () => {
-            result = $.SUBRULE($.decimalNumber);
+            result = $.SUBRULE($.symbol);
           },
         },
         {
@@ -174,7 +174,13 @@ class JISPParser extends EmbeddedActionsParser {
         entries.push([key, value]);
       });
       $.CONSUME(Tokens.MapClose);
-      return Object.fromEntries(entries);
+      const obj = Object.fromEntries(entries);
+      Object.defineProperty(obj, Symbol.for("@@jisp-map@@"), {
+        enumerable: false,
+        writable: false,
+        value: true,
+      });
+      return obj;
     });
 
     $.RULE("quoteNext", () => {

--- a/src/reader/tokenizer.js
+++ b/src/reader/tokenizer.js
@@ -53,7 +53,7 @@ const Tokens = {
   }),
   DecimalNumber: createToken({
     name: "DecimalNumber",
-    pattern: /\d+\.\d+|\.\d+|([1-9]\d*)|0/,
+    pattern: /[-+]?\d+\.\d+|\.\d+|[-+]?([1-9]\d*)|[-+]?0/,
   }),
   EmbeddedJavaScript: createToken({
     name: "EmbeddedJavascript",
@@ -81,7 +81,7 @@ const Tokens = {
   }),
   Symbol: createToken({
     name: "Symbol",
-    pattern: /[^:][-\w$?+/*!><|&\.\/%:]*/,
+    pattern: /[^:][-\w$?+/*!><|&\.\/%:=]*/,
   }),
 };
 


### PR DESCRIPTION
* Add `bind-js` macro
* Fix parsing of decimal numbers, now negative numbers are supported
* Add checks for if the value is indeed a JISP map, so we are not evaluating class instances and other javascript stuff